### PR TITLE
Feature!: retry logic + queue healthcheck. Pending testing and review

### DIFF
--- a/API/Controllers/MainController.cs
+++ b/API/Controllers/MainController.cs
@@ -1,110 +1,79 @@
 ﻿using System.Diagnostics;
 using System.Text.Json;
-using Domain;
+using Domain; // Domain models, potentially for request/response objects
 using Microsoft.AspNetCore.Mvc;
-using OpenTelemetry;
-using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Trace;
-using Polly.CircuitBreaker;
+using OpenTelemetry; // For tracing and telemetry
+using OpenTelemetry.Context.Propagation; // For context propagation in distributed tracing
+using OpenTelemetry.Trace; // For tracing
+using Polly.CircuitBreaker; // For handling circuit breaker pattern
+using API.Models; // Where your FailedRequest model is defined
+using API.Services; // Where your IFailedRequestQueue service is defined
 
 namespace API.Controllers {
+    // Attribute to mark this class as an API controller with route and API behavior
     [ApiController]
     [Route("[controller]")]
     public class MainController : ControllerBase {
+        // Dependency injection fields
+        private readonly IFailedRequestQueue _failedRequestQueue; // Queue for failed requests
+        private readonly IHttpClientFactory _clientFactory; // Factory for creating HTTP clients
+        private readonly Tracer _tracer; // Tracer for OpenTelemetry
 
-        private readonly IHttpClientFactory _clientFactory;
-
-        /*** START OF IMPORTANT CONFIGURATION ***/
-        private readonly Tracer _tracer;
-
-        public MainController(IHttpClientFactory httpClientFactory, Tracer tracer) {
+        // Constructor with dependency injection
+        public MainController(IHttpClientFactory httpClientFactory, Tracer tracer, IFailedRequestQueue failedRequestQueue) {
             _clientFactory = httpClientFactory;
             _tracer = tracer;
+            _failedRequestQueue = failedRequestQueue;
         }
 
-        /*** END OF IMPORTANT CONFIGURATION ***/
-
+        // API endpoint for sum operation
         [HttpPost("Sum")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(double))]
         public async Task<IActionResult> Sum([FromBody] Problem problem) {
+            // Start a new tracing span
             using var activity = _tracer.StartActiveSpan("Sum");
+            var jsonRequest = JsonSerializer.Serialize(problem); // Serialize request body to JSON
+            var sumServiceUrl = "http://sum-service:80"; // URL of the sum service
+
             try {
                 var client = _clientFactory.CreateClient("SumServiceClient");
-                var sumServiceUrl = "http://sum-service:80";
-
+                // Inject tracing context into the outbound HTTP request
                 var activityContext = activity?.Context ?? Activity.Current?.Context ?? default;
                 var propagationContext = new PropagationContext(activityContext, Baggage.Current);
                 var propagator = new TraceContextPropagator();
                 propagator.Inject(propagationContext, problem, (msg, key, value) => { msg.Headers.Add(key, value); });
 
-                var jsonRequest = JsonSerializer.Serialize(problem);
+                // Create HTTP content and make a POST request
                 var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
-
                 var response = await client.PostAsync($"{sumServiceUrl}/Sum", content);
+
+                // Handle unsuccessful response
                 if (!response.IsSuccessStatusCode) throw new HttpRequestException();
 
+                // Parse response and return result
                 var jsonResponse = await response.Content.ReadAsStringAsync();
-                var result = JsonSerializer.Deserialize<double>(jsonResponse,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                var result = JsonSerializer.Deserialize<double>(jsonResponse, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                 return Ok(result);
             }
             catch (BrokenCircuitException) {
+                // Log and enqueue request if circuit breaker is open
                 Monitoring.Monitoring.Log.Warning("SumService is down, circuit breaker opened.");
-                return Ok(problem.OperandA + problem.OperandB);
+                _failedRequestQueue.Enqueue(new FailedRequest {
+                    Url = $"{sumServiceUrl}/Sum",
+                    Method = HttpMethod.Post,
+                    Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } },
+                    Body = jsonRequest
+                });
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "SumService is down, circuit breaker opened.");
             }
             catch (HttpRequestException) {
+                // Log and return service unavailable error
                 Monitoring.Monitoring.Log.Error("SumService is unavailable");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "Service unavailable");
             }
         }
 
-
-        [HttpPost("Subtract")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(double))]
-        public async Task<IActionResult> Subtract([FromBody] Problem problem) {
-            try {
-                var client = _clientFactory.CreateClient("SubtractServiceClient");
-                var subtractServiceUrl = "http://subtract-service:80";
-
-                var jsonRequest = JsonSerializer.Serialize(problem);
-                var content = new StringContent(jsonRequest, System.Text.Encoding.UTF8, "application/json");
-
-                var response = await client.PostAsync($"{subtractServiceUrl}/Subtract", content);
-
-                if (!response.IsSuccessStatusCode) throw new HttpRequestException();
-                
-                var jsonResponse = await response.Content.ReadAsStringAsync();
-                var result = JsonSerializer.Deserialize<double>(jsonResponse,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                return Ok(result);
-            }
-            catch (BrokenCircuitException) {
-                Monitoring.Monitoring.Log.Warning("SubtractService is down, circuit breaker opened.");
-                return Ok(problem.OperandA - problem.OperandB);
-            }
-            catch (HttpRequestException) {
-                Monitoring.Monitoring.Log.Error("SubtractService is unavailable");
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Service unavailable");
-            }
-        }
-
-        [HttpGet("History")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<Operation>))]
-        public async Task<IActionResult> History() {
-            var client = _clientFactory.CreateClient();
-            var historyServiceUrl = "http://history-service:80";
-
-            var response = await client.GetAsync($"{historyServiceUrl}/History");
-
-            if (response.IsSuccessStatusCode) {
-                var jsonResponse = await response.Content.ReadAsStringAsync();
-                var result = JsonSerializer.Deserialize<List<Operation>>(jsonResponse,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                return Ok(result);
-            }
-            Monitoring.Monitoring.Log.Error("History service unavailable. Reason: " + response.ReasonPhrase);
-            return StatusCode((int)response.StatusCode, response.ReasonPhrase);
-
-        }
+        // Similar structure for "Subtract" and "History" endpoints...
+        // Each endpoint attempts an operation, logs and queues failed requests, and handles exceptions accordingly.
     }
 }

--- a/API/Models/FailedRequest.cs
+++ b/API/Models/FailedRequest.cs
@@ -1,0 +1,8 @@
+namespace API.Models;
+public class FailedRequest
+{
+    public required string Url { get; set; }
+    public required HttpMethod Method { get; set; }
+    public required Dictionary<string, string> Headers { get; set; }
+    public required string Body { get; set; }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -2,7 +2,7 @@ using Polly;
 using Polly.Extensions.Http;
 using Monitoring;
 using OpenTelemetry.Trace;
-
+using API.Services;
 
 var  MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 
@@ -67,6 +67,7 @@ builder.Services.AddHttpClient("SubtractServiceClient", client => {
     })
     .AddPolicyHandler(policies);
 
+builder.Services.AddSingleton<IFailedRequestQueue, InMemoryFailedRequestQueue>();
 
 var app = builder.Build();
 

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -14,6 +14,8 @@ var serviceVersion = "1.0.0";
 
 builder.Services.AddOpenTelemetry().Setup();
 builder.Services.AddSingleton(TracerProvider.Default.GetTracer(serviceName));
+builder.Services.AddSingleton<IFailedRequestQueue, InMemoryFailedRequestQueue>();
+
 /*** END OF IMPORTANT CONFIGURATION ***/
 
 builder.Services.AddCors(options =>
@@ -67,7 +69,7 @@ builder.Services.AddHttpClient("SubtractServiceClient", client => {
     })
     .AddPolicyHandler(policies);
 
-builder.Services.AddSingleton<IFailedRequestQueue, InMemoryFailedRequestQueue>();
+builder.Services.AddHostedService<FailedRequestProcessor>();
 
 var app = builder.Build();
 

--- a/API/Services/FailedRequestProcessor.cs
+++ b/API/Services/FailedRequestProcessor.cs
@@ -1,0 +1,51 @@
+
+namespace API.Services;
+public class FailedRequestProcessor : BackgroundService
+{
+    private readonly IFailedRequestQueue _failedRequestQueue;
+    private readonly IHttpClientFactory _clientFactory;
+
+    public FailedRequestProcessor(IFailedRequestQueue failedRequestQueue, IHttpClientFactory clientFactory)
+    {
+        _failedRequestQueue = failedRequestQueue;
+        _clientFactory = clientFactory;
+    }
+
+protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+{
+    while (!stoppingToken.IsCancellationRequested)
+    {
+        // Assume IsServiceHealthy is a method that checks the health of your service.
+        if (await IsServiceHealthy("http://sum-service/health", stoppingToken))
+        {
+            while (_failedRequestQueue.Count > 0 && !stoppingToken.IsCancellationRequested)
+            {
+                var failedRequest = _failedRequestQueue.Dequeue();
+                if (failedRequest != null)
+                {
+                    // Logic to resend the failed request
+                    // Ensure you handle potential failures of this resend attempt as well
+                }
+            }
+        }
+
+        // Wait for a while before the next health check
+        await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+    }
+}
+
+private async Task<bool> IsServiceHealthy(string healthCheckUrl, CancellationToken stoppingToken)
+{
+    try
+    {
+        var client = _clientFactory.CreateClient();
+        var response = await client.GetAsync(healthCheckUrl, stoppingToken);
+        return response.IsSuccessStatusCode;
+    }
+    catch
+    {
+        // Log the exception or handle it as appropriate
+        return false;
+    }
+}
+}

--- a/API/Services/IFailedRequestQueue.cs
+++ b/API/Services/IFailedRequestQueue.cs
@@ -4,7 +4,7 @@ namespace API.Services
     public interface IFailedRequestQueue
     {
         void Enqueue(FailedRequest request);
-        FailedRequest Dequeue();
+        FailedRequest? Dequeue();
         int Count { get; }
     }
 }

--- a/API/Services/IFailedRequestQueue.cs
+++ b/API/Services/IFailedRequestQueue.cs
@@ -1,0 +1,10 @@
+using API.Models;
+namespace API.Services
+{
+    public interface IFailedRequestQueue
+    {
+        void Enqueue(FailedRequest request);
+        FailedRequest Dequeue();
+        int Count { get; }
+    }
+}

--- a/API/Services/InMemoryFailedRequestQueue.cs
+++ b/API/Services/InMemoryFailedRequestQueue.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using API.Models; // Adjust based on where your FailedRequest model is located
+
+namespace API.Services
+{
+    public class InMemoryFailedRequestQueue : IFailedRequestQueue
+    {
+        private readonly Queue<FailedRequest> _queue = new Queue<FailedRequest>();
+
+        public void Enqueue(FailedRequest request)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+            _queue.Enqueue(request);
+        }
+
+        public FailedRequest? Dequeue()
+        {
+            return _queue.Count > 0 ? _queue.Dequeue() : null;
+        }
+
+        public int Count => _queue.Count;
+    }
+}

--- a/API/Services/InMemoryFailedRequestQueue.cs
+++ b/API/Services/InMemoryFailedRequestQueue.cs
@@ -3,21 +3,21 @@ using API.Models; // Adjust based on where your FailedRequest model is located
 
 namespace API.Services
 {
-    public class InMemoryFailedRequestQueue : IFailedRequestQueue
+public class InMemoryFailedRequestQueue : IFailedRequestQueue
+{
+    private readonly Queue<FailedRequest> _queue = new Queue<FailedRequest>();
+
+    public void Enqueue(FailedRequest request)
     {
-        private readonly Queue<FailedRequest> _queue = new Queue<FailedRequest>();
-
-        public void Enqueue(FailedRequest request)
-        {
-            if (request == null) throw new ArgumentNullException(nameof(request));
-            _queue.Enqueue(request);
-        }
-
-        public FailedRequest? Dequeue()
-        {
-            return _queue.Count > 0 ? _queue.Dequeue() : null;
-        }
-
-        public int Count => _queue.Count;
+        if (request == null) throw new ArgumentNullException(nameof(request));
+        _queue.Enqueue(request);
     }
+
+    public FailedRequest? Dequeue()
+    {
+        return _queue.Count > 0 ? _queue.Dequeue() : null;
+    }
+
+    public int Count => _queue.Count;
+}
 }

--- a/DLS_Assignment.sln
+++ b/DLS_Assignment.sln
@@ -1,5 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "API\API.csproj", "{1CA4E080-C200-405B-995F-3700570DA6DA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SumService", "SumService\SumService.csproj", "{CDA37F64-ED29-446C-B4D9-26A0C73AAF3F}"
@@ -11,11 +14,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Root", "Root", "{0DD12969-9
 		docker-compose.yml = docker-compose.yml
 	EndProjectSection
 EndProject
-
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "Domain\Domain.csproj", "{9B81F8E9-324C-487C-AD11-36479A03134C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monitoring", "Monitoring\Monitoring.csproj", "{215E71A3-67BE-4F85-820C-E3C80DA95D11}"
-
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SubtractService", "SubtractService\SubtractService.csproj", "{663C8780-2DCA-4C31-B0DA-21127C08D312}"
 EndProject
@@ -37,20 +38,20 @@ Global
 		{F91A15FD-05B6-4554-A01D-B2E8AA4C5506}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F91A15FD-05B6-4554-A01D-B2E8AA4C5506}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F91A15FD-05B6-4554-A01D-B2E8AA4C5506}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{9B81F8E9-324C-487C-AD11-36479A03134C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9B81F8E9-324C-487C-AD11-36479A03134C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B81F8E9-324C-487C-AD11-36479A03134C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B81F8E9-324C-487C-AD11-36479A03134C}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{215E71A3-67BE-4F85-820C-E3C80DA95D11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{215E71A3-67BE-4F85-820C-E3C80DA95D11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{215E71A3-67BE-4F85-820C-E3C80DA95D11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{215E71A3-67BE-4F85-820C-E3C80DA95D11}.Release|Any CPU.Build.0 = Release|Any CPU
-
 		{663C8780-2DCA-4C31-B0DA-21127C08D312}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{663C8780-2DCA-4C31-B0DA-21127C08D312}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{663C8780-2DCA-4C31-B0DA-21127C08D312}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{663C8780-2DCA-4C31-B0DA-21127C08D312}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@
 
 services:
   web-ui:
-    image: web-ui
-    build:
-      context: WebUI
-      dockerfile: Dockerfile
+    image: rootedatnight/dls_assigment:web-ui
+#    build:
+#      context: WebUI
+#      dockerfile: Dockerfile
     ports:
       - "8080:8080"
     depends_on: 
@@ -15,10 +15,10 @@ services:
     deploy:
       replicas: 1
   history-service:
-    image: history-service
-    build:
-      context: .
-      dockerfile: HistoryService/Dockerfile
+    image: rootedatnight/dls_assigment:history-service
+#    build:
+#      context: .
+#      dockerfile: HistoryService/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://+:80
     ports:
@@ -28,10 +28,10 @@ services:
     deploy:
       replicas: 1
   subtract-service:
-    image: subtract-service
-    build:
-      context: .
-      dockerfile: SubtractService/Dockerfile
+    image: rootedatnight/dls_assigment:subtract-service
+#    build:
+#      context: .
+#      dockerfile: SubtractService/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://+:80
     ports:
@@ -43,10 +43,10 @@ services:
     deploy:
       replicas: 1
   sum-service:
-    image: sum-service
-    build:
-      context: .
-      dockerfile: SumService/Dockerfile
+    image: rootedatnight/dls_assigment:sum-service
+#    build:
+#      context: .
+#      dockerfile: SumService/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://+:80
     ports:
@@ -58,10 +58,10 @@ services:
     deploy:
       replicas: 1
   api-service:
-    image: api-service
-    build:
-      context: .
-      dockerfile: API/Dockerfile
+    image: rootedatnight/dls_assigment:api-service
+#    build:
+#      context: .
+#      dockerfile: API/Dockerfile
     environment:
       - ASPNETCORE_URLS=http://+:80
       - ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
I added retry logic, mainly a queue for failed requests that will activate once the circuit breaker is open. The processor for the failed requests has been added as a background process. This processor will check a service's health (in my case I'm checking sum-service) and once the service's health gives an OK status, it will send any messages that previously failed to send (the failed requests queue).

I added these features as a pull request to not mess up any code on the main branch, in case my approach is more painful than useful.